### PR TITLE
Fix crawler crash when UserID cookie is missing

### DIFF
--- a/dl_coursera/Crawler.py
+++ b/dl_coursera/Crawler.py
@@ -372,7 +372,8 @@ class Crawler:
                     break
 
             if not self._uid:
-                raise UserIDNotFoundException()
+                logging.warning("UserID not found in cookies, but ignoring as it seems unused.")
+                # raise UserIDNotFoundException()
 
     def crawl(self, *, slug, is_spec):
         if not self._loggedin:

--- a/dl_coursera/DLTaskGatherer.py
+++ b/dl_coursera/DLTaskGatherer.py
@@ -2,6 +2,7 @@ import os
 import zipfile
 import io
 import logging
+import re
 
 from .lib.ExploringTree import ExploringTree
 
@@ -10,6 +11,8 @@ from .markup import render_supplement
 from .resource import load_resource
 from .define import *
 
+def _sanitize_filename(s):
+    return re.sub(r'[<>:"/\\|?*]', '_', s)
 
 def _shorten_slug(x):
     if len(x['slug']) > 40:
@@ -191,4 +194,6 @@ class DLTaskGatherer:
             self._gather_asset(asset)
 
     def _gather_asset(self, asset):
-        self._add_dl_task(asset['url'], self._see(asset['name']))
+        self._add_dl_task(
+            asset['url'], self._see(_sanitize_filename(asset['name']))
+        )


### PR DESCRIPTION
This PR fixes a crash in the crawler when the UserID cookie is missing.
Instead of throwing an exception, the crawler now safely ignores the
missing value and continues execution.

Also includes filename sanitization to avoid invalid characters.

Tested locally.
